### PR TITLE
Rework transformer notebook 1 for emotion classification

### DIFF
--- a/requirements_xai-for-transformer.txt
+++ b/requirements_xai-for-transformer.txt
@@ -1,7 +1,9 @@
 jupyter==1.1.1
 matplotlib==3.10.1
-torch==2.2.2
-transformers[torch]==4.38.2
-datasets==3.5.0
-evaluate==0.4.3
-numpy<2.0
+torch==2.6.0
+transformers[torch]==5.13.0
+datasets==5.0.0
+scikit-learn==1.9.0
+accelerate==1.14.0
+numpy==2.0.2
+requests==2.34.2

--- a/requirements_xai-for-transformer.txt
+++ b/requirements_xai-for-transformer.txt
@@ -1,8 +1,7 @@
-evaluate==0.4.3
 jupyter==1.1.1
 matplotlib==3.10.1
-opencv-python==4.11.0.86
-sacrebleu==2.5.1
-torch==2.6.0 
-torchvision==0.21.0 
-transformers[torch]==4.51.3
+torch==2.2.2
+transformers[torch]==4.38.2
+datasets==3.5.0
+evaluate==0.4.3
+numpy<2.0

--- a/xai-for-transformer/0-Template-Notebook.ipynb
+++ b/xai-for-transformer/0-Template-Notebook.ipynb
@@ -98,9 +98,20 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using device: mps\n"
+     ]
+    }
+   ],
    "source": [
     "import torch\n",
+    "import os\n",
+    "import zipfile\n",
+    "import requests\n",
     "\n",
     "from transformers import (\n",
     "    AutoTokenizer,\n",
@@ -109,7 +120,15 @@
     "\n",
     "# add your other imports here\n",
     "\n",
-    "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")"
+    "# Select the best available device: NVIDIA GPU (CUDA), Apple Silicon GPU (MPS), or CPU\n",
+    "if torch.cuda.is_available():\n",
+    "    device = torch.device(\"cuda\")\n",
+    "elif torch.backends.mps.is_available():\n",
+    "    device = torch.device(\"mps\")\n",
+    "else:\n",
+    "    device = torch.device(\"cpu\")\n",
+    "\n",
+    "print(f\"Using device: {device}\")"
    ]
   },
   {
@@ -134,152 +153,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/donatella.cea/opt/anaconda3/envs/xai/lib/python3.12/site-packages/huggingface_hub/file_download.py:949: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ee8e54a667e447d1ad536c85f82342dc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "tokenizer_config.json:   0%|          | 0.00/48.0 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "25dfad8268344548b3e934f90455a320",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json:   0%|          | 0.00/483 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8156e51f6d504208b9222d5155cb7db4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "vocab.txt: 0.00B [00:00, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e536f2f64b464b7591992b01f97814cc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "tokenizer.json: 0.00B [00:00, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b551aa8a84244e5f9478613f986e5cfc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model.safetensors:   0%|          | 0.00/268M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Some weights of DistilBertForSequenceClassification were not initialized from the model checkpoint at distilbert-base-uncased and are newly initialized: ['classifier.bias', 'classifier.weight', 'pre_classifier.bias', 'pre_classifier.weight']\n",
-      "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "DistilBertForSequenceClassification(\n",
-       "  (distilbert): DistilBertModel(\n",
-       "    (embeddings): Embeddings(\n",
-       "      (word_embeddings): Embedding(30522, 768, padding_idx=0)\n",
-       "      (position_embeddings): Embedding(512, 768)\n",
-       "      (LayerNorm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
-       "      (dropout): Dropout(p=0.1, inplace=False)\n",
-       "    )\n",
-       "    (transformer): Transformer(\n",
-       "      (layer): ModuleList(\n",
-       "        (0-5): 6 x TransformerBlock(\n",
-       "          (attention): MultiHeadSelfAttention(\n",
-       "            (dropout): Dropout(p=0.1, inplace=False)\n",
-       "            (q_lin): Linear(in_features=768, out_features=768, bias=True)\n",
-       "            (k_lin): Linear(in_features=768, out_features=768, bias=True)\n",
-       "            (v_lin): Linear(in_features=768, out_features=768, bias=True)\n",
-       "            (out_lin): Linear(in_features=768, out_features=768, bias=True)\n",
-       "          )\n",
-       "          (sa_layer_norm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
-       "          (ffn): FFN(\n",
-       "            (dropout): Dropout(p=0.1, inplace=False)\n",
-       "            (lin1): Linear(in_features=768, out_features=3072, bias=True)\n",
-       "            (lin2): Linear(in_features=3072, out_features=768, bias=True)\n",
-       "            (activation): GELUActivation()\n",
-       "          )\n",
-       "          (output_layer_norm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
-       "        )\n",
-       "      )\n",
-       "    )\n",
-       "  )\n",
-       "  (pre_classifier): Linear(in_features=768, out_features=768, bias=True)\n",
-       "  (classifier): Linear(in_features=768, out_features=6, bias=True)\n",
-       "  (dropout): Dropout(p=0.2, inplace=False)\n",
-       ")"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Pretrained DistilBERT model fine-tuned on SST-2 sentiment analysis\n",
-    "checkpoint = \"distilbert-base-uncased\"\n",
+    "# Fine-tuned DistilBERT emotion weights, hosted as a GitHub Release asset.\n",
+    "# NOTE: the download link becomes active once the weights Release is published.\n",
+    "url = \"https://github.com/HelmholtzAI-Consultants-Munich/XAI-Tutorials/releases/download/distilbert-emotion-weights/distilbert_emotion_weights.zip\"\n",
     "\n",
-    "# Load tokenizer and model from the Hugging Face Hub\n",
-    "tokenizer = AutoTokenizer.from_pretrained(checkpoint)\n",
-    "model = AutoModelForSequenceClassification.from_pretrained(\n",
-    "    checkpoint,\n",
-    "    num_labels=6\n",
-    "    ).to(device)\n",
+    "weights_path = \"../data/distilbert-emotion\"\n",
+    "zip_path = \"../data/distilbert_emotion_weights.zip\"\n",
+    "os.makedirs(\"../data\", exist_ok=True)\n",
     "\n",
-    "# Set the model to evaluation mode\n",
-    "model.eval()"
+    "if not os.path.exists(weights_path):\n",
+    "    # Reuse a local zip if it is already there (e.g. shared for testing),\n",
+    "    # otherwise download it from the Release.\n",
+    "    if not os.path.exists(zip_path):\n",
+    "        with open(zip_path, \"wb\") as f:\n",
+    "            f.write(requests.get(url).content)\n",
+    "    with zipfile.ZipFile(zip_path, \"r\") as zip_ref:\n",
+    "        zip_ref.extractall(\"../data/\")\n",
+    "\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(weights_path).to(device)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(weights_path)"
    ]
   },
   {
@@ -288,11 +184,11 @@
    "source": [
     "## XAI Method Name\n",
     "Please remember to add at least:\n",
-    "- method explanation\n",
+    "- method explanation (consider recording a short video 3-5 minutes)\n",
     "- reference\n",
     "- method implementation\n",
     "- examples and comments\n",
-    "- 1-3 open questions and the answers\n"
+    "- 1-3 open questions and the respective answers\n"
    ]
   },
   {

--- a/xai-for-transformer/0-Template-Notebook.ipynb
+++ b/xai-for-transformer/0-Template-Notebook.ipynb
@@ -1,0 +1,325 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![logo](https://github.com/HelmholtzAI-Consultants-Munich/XAI-Tutorials/blob/main/docs/source/_figures/Helmholtz-AI.png?raw=true)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# XAI for Transformers: <Method's title>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This Notebook shows ... \n",
+    "\n",
+    "--------"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting Started\n",
+    "\n",
+    "### Setup Colab environment\n",
+    "\n",
+    "If you installed the packages and requirements on your machine, you can skip this section and start from the import section.\n",
+    "Otherwise, you can follow and execute the tutorial on your browser. To start working on the notebook, click on the following button. This will open this page in the Colab environment, and you will be able to execute the code on your own.\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/HelmholtzAI-Consultants-Munich/XAI-Tutorials/blob/main/xai-for-transformer/2-Tutorial_AttentionMaps_Text.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that you opened the notebook in Google Colab follow the next step:\n",
+    "\n",
+    "1. Run this cell to connect your Google Drive to Colab and install packages\n",
+    "2. Allow this notebook to access your Google Drive files. Click on 'Yes', and select your account.\n",
+    "3. \"Google Drive for desktop wants to access your Google Account\". Click on 'Allow'.\n",
+    "   \n",
+    "A folder has been created in your Drive, and you can navigate it through the lefthand panel in Colab. You might also receive an email that informs you about the access on your Google Drive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mount drive folder to dbe abale to download repo\n",
+    "# from google.colab import drive\n",
+    "# drive.mount('/content/drive')\n",
+    "\n",
+    "# Switch to correct folder'\n",
+    "# %cd /content/drive/MyDrive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Don't run this cell if you already cloned the repo \n",
+    "# %rm -r XAI-Tutorials\n",
+    "# !git clone --branch main https://github.com/HelmholtzAI-Consultants-Munich/XAI-Tutorials.git"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install al required dependencies and package versions\n",
+    "# %cd XAI-Tutorials\n",
+    "# !pip install -r requirements_xai-for-transformer.txt\n",
+    "# %cd xai-for-transformer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "from transformers import (\n",
+    "    AutoTokenizer,\n",
+    "    AutoModelForSequenceClassification,\n",
+    ")\n",
+    "\n",
+    "# add your other imports here\n",
+    "\n",
+    "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model Loading\n",
+    "\n",
+    "In the notebook [*1-Tutorial_Transformer_Model.ipynb*](./1-Tutorial_Transformer_Model.ipynb), we introduced the Transformer architecture and the DistilBERT model used throughout this tutorial series.\n",
+    "\n",
+    "Rather than training a model from scratch, we use the pretrained **DistilBERT** model (`distilbert-base-uncased`) with a sequence classification head configured for six emotion classes. At this stage, the classification head is randomly initialized, allowing us to develop and test the XAI pipeline (e.g., SHAP, LIME, and Integrated Gradients) independently of model performance.\n",
+    "\n",
+    "Note: Once our own DistilBERT model has been fine-tuned on the emotion dataset, we can simply replace the pretrained checkpoint with the fine-tuned model while keeping the rest of the explainability workflow unchanged.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/donatella.cea/opt/anaconda3/envs/xai/lib/python3.12/site-packages/huggingface_hub/file_download.py:949: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ee8e54a667e447d1ad536c85f82342dc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tokenizer_config.json:   0%|          | 0.00/48.0 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "25dfad8268344548b3e934f90455a320",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/483 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8156e51f6d504208b9222d5155cb7db4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "vocab.txt: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e536f2f64b464b7591992b01f97814cc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tokenizer.json: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b551aa8a84244e5f9478613f986e5cfc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/268M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Some weights of DistilBertForSequenceClassification were not initialized from the model checkpoint at distilbert-base-uncased and are newly initialized: ['classifier.bias', 'classifier.weight', 'pre_classifier.bias', 'pre_classifier.weight']\n",
+      "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "DistilBertForSequenceClassification(\n",
+       "  (distilbert): DistilBertModel(\n",
+       "    (embeddings): Embeddings(\n",
+       "      (word_embeddings): Embedding(30522, 768, padding_idx=0)\n",
+       "      (position_embeddings): Embedding(512, 768)\n",
+       "      (LayerNorm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
+       "      (dropout): Dropout(p=0.1, inplace=False)\n",
+       "    )\n",
+       "    (transformer): Transformer(\n",
+       "      (layer): ModuleList(\n",
+       "        (0-5): 6 x TransformerBlock(\n",
+       "          (attention): MultiHeadSelfAttention(\n",
+       "            (dropout): Dropout(p=0.1, inplace=False)\n",
+       "            (q_lin): Linear(in_features=768, out_features=768, bias=True)\n",
+       "            (k_lin): Linear(in_features=768, out_features=768, bias=True)\n",
+       "            (v_lin): Linear(in_features=768, out_features=768, bias=True)\n",
+       "            (out_lin): Linear(in_features=768, out_features=768, bias=True)\n",
+       "          )\n",
+       "          (sa_layer_norm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
+       "          (ffn): FFN(\n",
+       "            (dropout): Dropout(p=0.1, inplace=False)\n",
+       "            (lin1): Linear(in_features=768, out_features=3072, bias=True)\n",
+       "            (lin2): Linear(in_features=3072, out_features=768, bias=True)\n",
+       "            (activation): GELUActivation()\n",
+       "          )\n",
+       "          (output_layer_norm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
+       "        )\n",
+       "      )\n",
+       "    )\n",
+       "  )\n",
+       "  (pre_classifier): Linear(in_features=768, out_features=768, bias=True)\n",
+       "  (classifier): Linear(in_features=768, out_features=6, bias=True)\n",
+       "  (dropout): Dropout(p=0.2, inplace=False)\n",
+       ")"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Pretrained DistilBERT model fine-tuned on SST-2 sentiment analysis\n",
+    "checkpoint = \"distilbert-base-uncased\"\n",
+    "\n",
+    "# Load tokenizer and model from the Hugging Face Hub\n",
+    "tokenizer = AutoTokenizer.from_pretrained(checkpoint)\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(\n",
+    "    checkpoint,\n",
+    "    num_labels=6\n",
+    "    ).to(device)\n",
+    "\n",
+    "# Set the model to evaluation mode\n",
+    "model.eval()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## XAI Method Name\n",
+    "Please remember to add at least:\n",
+    "- method explanation\n",
+    "- reference\n",
+    "- method implementation\n",
+    "- examples and comments\n",
+    "- 1-3 open questions and the answers\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "xai",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/xai-for-transformer/1-Tutorial_Transformer_Model-Translation.ipynb
+++ b/xai-for-transformer/1-Tutorial_Transformer_Model-Translation.ipynb
@@ -34,7 +34,7 @@
     "If you installed the packages and requirements on your  machine, you can skip this section and start from the import section.\n",
     "Otherwise, you can follow and execute the tutorial on your browser. To start working on the notebook, click on the following button. This will open this page in the Colab environment, and you will be able to execute the code on your own.\n",
     "\n",
-    "<a href=\"https://colab.research.google.com/github/HelmholtzAI-Consultants-Munich/XAI-Tutorials/blob/main/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/HelmholtzAI-Consultants-Munich/XAI-Tutorials/blob/main/xai-for-transformer/1-Tutorial_Transformer_Model-Translation.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
+++ b/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
@@ -151,7 +151,7 @@
     "\n",
     "Transformers largely replaced earlier sequence models (such as recurrent neural networks): their attention mechanism processes all tokens in parallel and captures long-range relationships between them directly, which makes them both faster to train and more accurate. This architecture underpins today's large language models. The video below builds this intuition and visualizes the overall architecture.\n",
     "\n",
-    "*TODO: Add video 1*"
+    "*Watch: [Transformer Basic – Overview](https://www.youtube.com/watch?v=aqIZG521uwE&list=PLK2tkofg74mk) · Read more: [Introduction to Transformers](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#introduction-to-transformers)*"
    ]
   },
   {
@@ -171,12 +171,14 @@
     "\n",
     "- **Input Embeddings:** After tokenization, each token is converted into a high-dimensional vector representation called embedding. These embeddings capture semantic relationships between tokens and serve as numerical input to the transformer.\n",
     "\n",
-    "    *TODO: add line of code + add video 2*\n",
+    "    *TODO: add line of code*\n",
+    "\n",
+    "    *Watch: [Transformer Basic – Word Embedding](https://www.youtube.com/watch?v=Z7K2uodMnts&list=PLK2tkofg74mk) · Read more: [Word embedding](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#word-embedding)*\n",
     "\n",
     "\n",
     "- **Positional Encodings:** Unlike recurrent or convolutional networks, transformers do not inherently capture the order of tokens in a sequence. To provide positional information, positional encodings are added to the input embeddings. These encodings have the same dimensionality as the embeddings and are typically generated using sine and cosine functions of varying frequencies. This approach assigns a unique representation to each position, enabling the model to distinguish between tokens based on their order within the sequence.\n",
     "\n",
-    "    *TODO: add video 3*"
+    "    *Watch: [Transformer Basic – Positional Encoding](https://www.youtube.com/watch?v=1s_XUBB1RsY&list=PLK2tkofg74mk) · Read more: [Positional encoding](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#positional-encoding)*"
    ]
   },
   {
@@ -216,11 +218,13 @@
     "\n",
     "Before diving into the implementation, it is helpful to first develop an intuitive understanding of the attention mechanism. The following video provides a clear explanation of how attention works and why it is a key component of Transformer models:\n",
     "\n",
-    "Attention Mechanism Explained: *TODO: Insert video link*\n",
+    "Attention Mechanism Explained: *Watch: [Transformer Basic – Self Attention](https://www.youtube.com/watch?v=6njflIo3BHI&list=PLK2tkofg74mk) · Read more: [Self-attention](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#self-attention)*\n",
     "\n",
     "For a deeper understanding of the attention mechanisms used in the Transformer decoder, including Masked Self-Attention and Cross-Attention, you can also watch: (TODO: I would rather mention this after with the decoder part)\n",
     "\n",
-    "Attention in the Decoder (Masked and Cross-Attention): *TODO: Insert video link*\n",
+    "Attention in the Decoder (Masked and Cross-Attention): *Watch: [Transformer Basic – Masked and Cross Attention](https://www.youtube.com/watch?v=NONly4i_-3Q&list=PLK2tkofg74mk) · Read more: [Masked self-attention and cross-attention](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#masked-self-attention-and-cross-attention)*\n",
+    "\n",
+    "Multi-Head Attention: *Watch: [Transformer Basic – Multi-Head Attention](https://www.youtube.com/watch?v=99100CbBsck&list=PLK2tkofg74mk) · Read more: [Multi head attention](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#multi-head-attention)*\n",
     "\n",
     "After reviewing these concepts, we will examine the code implementation of Multi-Head Attention in more detail."
    ]
@@ -295,7 +299,7 @@
     "\n",
     "The original Transformer has two components, an **encoder** and a **decoder**. Modern models often use only one, depending on the task. Since this course focuses on text *classification*, we will use the **encoder** only.\n",
     "\n",
-    "*TODO: add video*\n",
+    "*Watch: [Transformer Basic – Putting it all together](https://www.youtube.com/watch?v=SE6CH0plnW0&list=PLK2tkofg74mk) · Read more: [Putting them all together](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#putting-them-all-together)*\n",
     "\n",
     "#### Encoder\n",
     "\n",
@@ -484,7 +488,7 @@
     "\n",
     "One of the most influential encoder-only Transformer models is **BERT (Bidirectional Encoder Representations from Transformers)**. Unlike the original encoder-decoder Transformer, BERT consists only of the encoder stack and is designed to learn contextual representations of text by attending to both the left and right context of every token simultaneously.\n",
     "\n",
-    "*TODO: add video*\n",
+    "*Watch: [Transformer Basic – BERT](https://www.youtube.com/watch?v=s0OQoRuNPTg&list=PLK2tkofg74mk) · Read more: [Bidirectional Encoder Representations from Transformers (BERT)](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#bidirectional-encoder-representations-from-transformers-bert)*\n",
     "\n",
     "In this course, we will use **DistilBERT**, a lightweight version of BERT that retains most of its performance while requiring fewer parameters and less computational resources. This makes it particularly suitable for educational purposes and explainability analyses.\n",
     "\n",

--- a/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
+++ b/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
@@ -357,7 +357,7 @@
     "\n",
     "Since this course focuses on understanding and classifying text, **we do not use the decoder here.** Its full implementation, together with a machine-translation fine-tuning example, is covered in the companion notebook:\n",
     "\n",
-    "*TODO: add link to translation notebook (Old-1-Tutorial_Transformer_Model.ipynb).*"
+    "[*1-Tutorial_Transformer_Model-Translation.ipynb*](./1-Tutorial_Transformer_Model-Translation.ipynb)"
    ]
   },
   {

--- a/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
+++ b/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
@@ -303,10 +303,10 @@
     "\n",
     "#### Encoder\n",
     "\n",
-    "The encoder turns the input sequence into a contextualized representation that captures the relationships between tokens. It is a stack of identical layers, each containing:\n",
+    "The encoder turns the input sequence into a contextualized representation that captures the relationships between tokens. It is a stack of identical layers — the original Transformer uses six — each containing:\n",
     "\n",
     "* **Multi-Head Self-Attention**, which lets each token attend to all other tokens in the sequence.\n",
-    "* **Feed-Forward Network**, which refines each token's representation independently.\n",
+    "* **Feed-Forward Network**, which refines each token's representation independently, applying two linear transformations with a ReLU activation in between.\n",
     "* **Residual Connections and Layer Normalization**, which stabilize training and help information flow.\n",
     "\n",
     "The final layer outputs a sequence of vectors that encodes the meaning and context of the input, ready for a downstream task such as classification."

--- a/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
+++ b/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
@@ -96,23 +96,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import math\n",
     "\n",
+    "import numpy as np\n",
     "import torch\n",
     "import torch.nn as nn\n",
     "\n",
-    "import numpy as np\n",
-    "\n",
+    "from datasets import load_dataset\n",
+    "from sklearn.metrics import accuracy_score, f1_score\n",
     "from transformers import (\n",
     "    AutoTokenizer,\n",
     "    AutoModelForSequenceClassification,\n",
+    "    TrainingArguments,\n",
+    "    Trainer,\n",
+    "    DataCollatorWithPadding,\n",
     ")\n",
     "\n",
-    "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")"
+    "# Use GPU (CUDA), Apple Silicon (MPS), or CPU - whichever is available\n",
+    "if torch.cuda.is_available():\n",
+    "    device = torch.device(\"cuda\")\n",
+    "elif torch.backends.mps.is_available():\n",
+    "    device = torch.device(\"mps\")\n",
+    "else:\n",
+    "    device = torch.device(\"cpu\")"
    ]
   },
   {
@@ -128,7 +138,7 @@
    "source": [
     "## Build a Transformer Model\n",
     "\n",
-    "In the subsequent sections we will show you how to build a transformer architecture using PyTorch, we alternate a step-by-step implementaion with a small video explanation of the specific component.\n",
+    "In the subsequent sections we will show you how to build a transformer architecture using PyTorch, we alternate a step-by-step implementation with a small video explanation of the specific component.\n",
     "\n",
     "***Note: we provide all references [here](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#references).***"
    ]
@@ -138,7 +148,8 @@
    "metadata": {},
    "source": [
     "### Motivation\n",
-    "Let's start with an introduction to the reason why transofmers became so popular and a visualization of the whole architecture\n",
+    "\n",
+    "Transformers largely replaced earlier sequence models (such as recurrent neural networks): their attention mechanism processes all tokens in parallel and captures long-range relationships between them directly, which makes them both faster to train and more accurate. This architecture underpins today's large language models. The video below builds this intuition and visualizes the overall architecture.\n",
     "\n",
     "*TODO: Add video 1*"
    ]
@@ -151,19 +162,19 @@
     "\n",
     "Before an input sequence can be processed by a transformer model, it undergoes several preprocessing steps: \n",
     "\n",
-    "- **Tokenization:** is a fundamental step in NLP. It involves splitting text into smaller units called tokens. Depending on the tokenization strategy, tokens can be words, subwords, characters or even an entire sentence.\n",
+    "- **Tokenization:** is a fundamental step in Natural Language Processing (NLP). It involves splitting text into smaller units called tokens. Depending on the tokenization strategy, tokens can be words, subwords, characters or even an entire sentence.\n",
     "\n",
     "  Example:  \n",
     "  Text: \"Natural Language Processing is fascinating.\"  \n",
     "  Tokens: [\"Natural\", \"Language\", \"Processing\", \"is\", \"fascinating\"]  \n",
     "  *TODO: add line of code* \n",
     "\n",
-    "- **Input Embeddings:** After tokenization, each token is converted into a  high-dimensional vector representation called embedding. These embeddings wcapture semantic relationshios between tokens and serve as numerical input to the transformer.\n",
+    "- **Input Embeddings:** After tokenization, each token is converted into a high-dimensional vector representation called embedding. These embeddings capture semantic relationships between tokens and serve as numerical input to the transformer.\n",
     "\n",
     "    *TODO: add line of code + add video 2*\n",
     "\n",
     "\n",
-    "- **Positional Encodings:** Unlike recurrent or convolutional network, transformers do not inherently capture the order of tokens in a sequence. To provide positional information, positional encodings are added to the input embeddings. These encodings have the same dimensionality as the embeddings and are typically generated using sine and cosine functions of varying frequencies. This approach assigns a unique representation to each position, enabling the model to distinguish between tokens based on their order within the sequence.\n",
+    "- **Positional Encodings:** Unlike recurrent or convolutional networks, transformers do not inherently capture the order of tokens in a sequence. To provide positional information, positional encodings are added to the input embeddings. These encodings have the same dimensionality as the embeddings and are typically generated using sine and cosine functions of varying frequencies. This approach assigns a unique representation to each position, enabling the model to distinguish between tokens based on their order within the sequence.\n",
     "\n",
     "    *TODO: add video 3*"
    ]
@@ -282,21 +293,19 @@
    "source": [
     "### Putting It All Together\n",
     "\n",
-    "The original Transformer architecture consists of two main components: an **encoder** and a **decoder**. While many modern Transformer-based models use only one of these components, depending on the task they are designed to perform, it is useful to first understand the complete architecture before exploring specific applications.\n",
+    "The original Transformer has two components, an **encoder** and a **decoder**. Modern models often use only one, depending on the task. Since this course focuses on text *classification*, we will use the **encoder** only.\n",
     "\n",
     "*TODO: add video*\n",
     "\n",
     "#### Encoder\n",
     "\n",
-    "The encoder processes the input sequence and transforms it into a contextualized representation that captures the relationships between tokens.\n",
+    "The encoder turns the input sequence into a contextualized representation that captures the relationships between tokens. It is a stack of identical layers, each containing:\n",
     "\n",
-    "It is composed of a stack of identical layers, each containing:\n",
+    "* **Multi-Head Self-Attention**, which lets each token attend to all other tokens in the sequence.\n",
+    "* **Feed-Forward Network**, which refines each token's representation independently.\n",
+    "* **Residual Connections and Layer Normalization**, which stabilize training and help information flow.\n",
     "\n",
-    "* Multi-Head Self-Attention, which allows each token to attend to all other tokens in the sequence.\n",
-    "* Feed-Forward Network, which independently refines the representation of each token.\n",
-    "* Residual Connections and Layer Normalization, which improve training stability and help information flow through the network.\n",
-    "\n",
-    "The output of the final encoder layer is a sequence of vectors that encodes the meaning and context of the input sequence. This representation can then be used by the decoder or by downstream tasks.\n"
+    "The final layer outputs a sequence of vectors that encodes the meaning and context of the input, ready for a downstream task such as classification."
    ]
   },
   {
@@ -340,22 +349,11 @@
    "source": [
     "#### Decoder\n",
     "\n",
-    "The decoder generates the output sequence one token at a time based on the encoded input and previously generated tokens.\n",
+    "The **decoder** generates an output sequence one token at a time, using masked self-attention (so a token cannot attend to future positions) and cross-attention over the encoder's output. It is mainly used for sequence-generation tasks such as machine translation.\n",
     "\n",
-    "Each decoder layer contains:\n",
+    "Since this course focuses on understanding and classifying text, **we do not use the decoder here.** Its full implementation, together with a machine-translation fine-tuning example, is covered in the companion notebook:\n",
     "\n",
-    "* Masked Multi-Head Self-Attention, which prevents tokens from attending to future positions.\n",
-    "* Encoder-Decoder Attention (Cross-Attention), which allows the decoder to focus on relevant parts of the encoder output.\n",
-    "* Feed-Forward Network, which further processes the token representations.\n",
-    "* Residual Connections and Layer Normalization, which improve training stability.\n",
-    "\n",
-    "The final decoder output is passed through a linear layer and a softmax function to produce probabilities over the vocabulary and generate the next token in the sequence.\n",
-    "\n",
-    "In this course, we focus on Transformer models for understanding and classifying text. Therefore, we will mainly work with encoder-based architectures (e.g., BERT) and will not use the decoder component, which is primarily designed for sequence generation tasks such as machine translation and text generation.\n",
-    "\n",
-    "If you are interested in the implementation details and the fine-tuning process for a machine translation task, please refer to the accompanying notebook:\n",
-    "\n",
-    "TODO: add link to translation notebook."
+    "*TODO: add link to translation notebook (Old-1-Tutorial_Transformer_Model.ipynb).*"
    ]
   },
   {
@@ -482,7 +480,7 @@
     "\n",
     "The previous sections introduced the original Transformer architecture and demonstrated how its main components can be assembled into an encoder-only Transformer classifier.\n",
     "\n",
-    "In practice, however, modern Natural Language Processing (NLP) applications rarely train Transformer models from scratch. Instead, they rely on **pretrained language models**, which are first trained on large text corpora and later adapted to specific downstream tasks through fine-tuning.\n",
+    "In practice, however, modern NLP applications rarely train Transformer models from scratch. Instead, they rely on **pretrained language models**, which are first trained on large text corpora and later adapted to specific downstream tasks through fine-tuning.\n",
     "\n",
     "One of the most influential encoder-only Transformer models is **BERT (Bidirectional Encoder Representations from Transformers)**. Unlike the original encoder-decoder Transformer, BERT consists only of the encoder stack and is designed to learn contextual representations of text by attending to both the left and right context of every token simultaneously.\n",
     "\n",
@@ -519,134 +517,99 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Extra Material: Finetune a Transformer Model (TODO: update for classification task)\n",
+    "## Extra Material: Fine-tune a Transformer Model\n",
     "\n",
-    "In the subsequent sections we will show you how to fine-tune a transformer model using a pre-trained model from [Huggingface](https://huggingface.co/docs/transformers/index)."
+    "In the subsequent sections we will show you how to fine-tune a pre-trained Transformer model from [Hugging Face](https://huggingface.co/docs/transformers/index) on a text-classification task."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our goal is to fine-tune a pre-trained seq2seq model from Huggingface for a translation task, i.e. translating english to german text.  \n",
-    "In this example we use the smaller version of the pre-trained Text-To-Text Transfer Transformer (T5) \"T5-small\" from google with 60 million parameters.  \n",
-    "You can find the model card [here](https://huggingface.co/google-t5/t5-small).  "
+    "Our goal is to fine-tune the pre-trained **DistilBERT** model for an emotion-classification task, i.e. predicting the emotion expressed in a short piece of text.\n",
+    "We use `distilbert-base-uncased`, the lightweight version of BERT introduced above.\n",
+    "You can find the model card [here](https://huggingface.co/distilbert/distilbert-base-uncased)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = \"google-t5/t5-small\""
+    "checkpoint = \"distilbert-base-uncased\""
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first step for fine-tuning a model is to retrieve a fine-tuning dataset and prepare it for the translation tasks.  \n",
-    "In our case we use the \"opus_books\" dataset, which contains parallel text in German (de) and English (en).  \n",
-    "In addition, we set the source language to English and the target language to German and define a task-specific prefix used by t5-small to understand the task, in this case, translating English text to German."
+    "The first step for fine-tuning a model is to load a dataset and prepare it for the classification task.\n",
+    "Here we use the [`dair-ai/emotion`](https://huggingface.co/datasets/dair-ai/emotion) dataset, which contains English tweets labeled with one of six emotions: *sadness, joy, love, anger, fear,* and *surprise*."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "books = load_dataset(\"opus_books\", \"de-en\")\n",
-    "books = books[\"train\"].train_test_split(test_size=0.2)\n",
+    "emotion = load_dataset(\"dair-ai/emotion\", \"split\")\n",
     "\n",
-    "source_lang = \"en\"\n",
-    "target_lang = \"de\"\n",
-    "prefix = \"Translate English to German: \""
+    "labels = emotion[\"train\"].features[\"label\"].names\n",
+    "num_labels = len(labels)\n",
+    "id2label = {i: label for i, label in enumerate(labels)}\n",
+    "label2id = {label: i for i, label in enumerate(labels)}\n",
+    "\n",
+    "labels"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we initialize a tokenizer based on the specified model checkpoint, which will convert text into token IDs that the model can process  \n",
-    "and define a pre-processing function that prepares batches of translation examples for the translation task by:\n",
-    "- Prepending the task-specific prefix to the source language sentences.\n",
-    "- Extracting the corresponding target language sentences.\n",
-    "- Tokenizing both the inputs and targets into sequences of tokens suitable for input to the t5-small model."
+    "Next, we initialize a tokenizer based on the specified model checkpoint, which converts text into token IDs that the model can process.\n",
+    "We then define a pre-processing function that tokenizes each example's text (truncating long sequences) and apply it to the whole dataset."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2ab760799db46dba80c90f5e112f666",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/41173 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3964ab31489b4334ba62d01c1c3567cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10294 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tokenizer = AutoTokenizer.from_pretrained(checkpoint)\n",
     "\n",
     "def preprocess_function(examples):\n",
-    "    inputs = [prefix + example[source_lang] for example in examples[\"translation\"]]\n",
-    "    targets = [example[target_lang] for example in examples[\"translation\"]]\n",
-    "    model_inputs = tokenizer(inputs, text_target=targets, max_length=128, truncation=True)\n",
-    "    return model_inputs\n",
+    "    return tokenizer(examples[\"text\"], truncation=True, max_length=128)\n",
     "\n",
-    "tokenized_books = books.map(preprocess_function, batched=True)"
+    "tokenized_emotion = emotion.map(preprocess_function, batched=True)\n",
+    "data_collator = DataCollatorWithPadding(tokenizer=tokenizer)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For setting up the model we need to define the training arguments for our t5-small model using the `Seq2SeqTrainingArguments` class from the Hugging Face Transformers library.  \n",
-    "The training arguments include settings for the learning rate, batch size, number of epochs, evaluation strategy, model checkpointing, etc."
+    "For setting up the training we define the training arguments using the `TrainingArguments` class from the Hugging Face Transformers library.\n",
+    "The training arguments include settings such as the learning rate, batch size, number of epochs, evaluation strategy, and weight decay."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_args = Seq2SeqTrainingArguments(\n",
-    "    output_dir=\"german-english\",\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir=\"distilbert-emotion\",\n",
     "    eval_strategy=\"epoch\",\n",
-    "    learning_rate=2e-3,\n",
-    "    per_device_train_batch_size=64,\n",
-    "    per_device_eval_batch_size=64,\n",
+    "    learning_rate=2e-5,\n",
+    "    per_device_train_batch_size=16,\n",
+    "    per_device_eval_batch_size=32,\n",
     "    weight_decay=0.01,\n",
-    "    save_total_limit=3,\n",
-    "    num_train_epochs=10,\n",
-    "    predict_with_generate=True,\n",
-    "    fp16=False, \n",
+    "    num_train_epochs=3,\n",
+    "    save_total_limit=2,\n",
     "    push_to_hub=False,\n",
     ")"
    ]
@@ -655,200 +618,107 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition to the tarining arguments, we need to define the evaluation metrics for our model.  \n",
-    "Here, we use the SacreBLEU metric, which is a standard evaluation metric for machine translation tasks,  \n",
-    "providing a BLEU (Bilingual Evaluation Understudy) score, which measures the quality of text generated by the model compared to reference translations."
+    "In addition to the training arguments, we define the evaluation metrics for our model.\n",
+    "For a classification task we report **accuracy** and the **weighted F1-score**, which balances precision and recall across the (imbalanced) emotion classes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "metric = evaluate.load(\"sacrebleu\")\n",
-    "\n",
-    "def postprocess_text(preds, labels):\n",
-    "    preds = [pred.strip() for pred in preds]\n",
-    "    labels = [[label.strip()] for label in labels]\n",
-    "\n",
-    "    return preds, labels\n",
-    "\n",
     "def compute_metrics(eval_preds):\n",
-    "    preds, labels = eval_preds\n",
-    "    if isinstance(preds, tuple):\n",
-    "        preds = preds[0]\n",
-    "    decoded_preds = tokenizer.batch_decode(preds, skip_special_tokens=True)\n",
-    "\n",
-    "    labels = np.where(labels != -100, labels, tokenizer.pad_token_id)\n",
-    "    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)\n",
-    "\n",
-    "    decoded_preds, decoded_labels = postprocess_text(decoded_preds, decoded_labels)\n",
-    "\n",
-    "    result = metric.compute(predictions=decoded_preds, references=decoded_labels)\n",
-    "    result = {\"bleu\": result[\"score\"]}\n",
-    "\n",
-    "    prediction_lens = [np.count_nonzero(pred != tokenizer.pad_token_id) for pred in preds]\n",
-    "    result[\"gen_len\"] = np.mean(prediction_lens) # average number of non-pad tokens in predictions (model output)\n",
-    "    result = {k: round(v, 4) for k, v in result.items()}\n",
-    "    return result"
+    "    logits, labels = eval_preds\n",
+    "    predictions = np.argmax(logits, axis=1)\n",
+    "    return {\n",
+    "        \"accuracy\": accuracy_score(labels, predictions),\n",
+    "        \"f1\": f1_score(labels, predictions, average=\"weighted\"),\n",
+    "    }"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we are finally ready to fine-tune the T5-small for our translation task.  \n",
-    "Therefore, we initializes the model using the pre-trained weights and configuration from the specified checkpoint.  \n",
-    "The data collator is responsible for dynamically padding the input sequences to the same length within a batch.  \n",
-    "This is important because batches often contain sequences of varying lengths.\n",
+    "Now we are ready to fine-tune DistilBERT for our emotion-classification task.\n",
+    "We initialize the model from the pre-trained checkpoint, adding a classification head sized to the six emotion labels.\n",
+    "The data collator dynamically pads the input sequences to the same length within each batch.\n",
     "\n",
-    "After initilizing the Seq2SeqTrainer we can start the training/fine-tuning of the model.\n",
+    "After initializing the `Trainer`, we can start the training/fine-tuning of the model.\n",
     "\n",
-    "*Note: for demonstration purpose we select only a small subsample of the train and test data.*"
+    "*Note: for demonstration purposes we select only a small subsample of the train and validation data. The fully fine-tuned weights are provided below.*"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/8g/7wdchs993770j0nbzbt5p0_r0000gn/T/ipykernel_9213/688654782.py:4: FutureWarning: `tokenizer` is deprecated and will be removed in version 5.0.0 for `Seq2SeqTrainer.__init__`. Use `processing_class` instead.\n",
-      "  trainer = Seq2SeqTrainer(\n",
-      "Passing a tuple of `past_key_values` is deprecated and will be removed in Transformers v4.48.0. You should pass an instance of `EncoderDecoderCache` instead, e.g. `past_key_values=EncoderDecoderCache.from_legacy_cache(past_key_values)`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "    <div>\n",
-       "      \n",
-       "      <progress value='40' max='40' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [40/40 02:20, Epoch 10/10]\n",
-       "    </div>\n",
-       "    <table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       " <tr style=\"text-align: left;\">\n",
-       "      <th>Epoch</th>\n",
-       "      <th>Training Loss</th>\n",
-       "      <th>Validation Loss</th>\n",
-       "      <th>Bleu</th>\n",
-       "      <th>Gen Len</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <td>1</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.228585</td>\n",
-       "      <td>3.361700</td>\n",
-       "      <td>17.520000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>2</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.292926</td>\n",
-       "      <td>3.867000</td>\n",
-       "      <td>17.840000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>3</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.289472</td>\n",
-       "      <td>4.270300</td>\n",
-       "      <td>17.600000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>4</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.315202</td>\n",
-       "      <td>4.109700</td>\n",
-       "      <td>17.920000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>5</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.358456</td>\n",
-       "      <td>4.277300</td>\n",
-       "      <td>17.960000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>6</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.403290</td>\n",
-       "      <td>3.727500</td>\n",
-       "      <td>17.880000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>7</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.434193</td>\n",
-       "      <td>3.710900</td>\n",
-       "      <td>17.740000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>8</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.464301</td>\n",
-       "      <td>3.830200</td>\n",
-       "      <td>17.560000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>9</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.483917</td>\n",
-       "      <td>3.844700</td>\n",
-       "      <td>17.560000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <td>10</td>\n",
-       "      <td>No log</td>\n",
-       "      <td>2.493277</td>\n",
-       "      <td>3.851900</td>\n",
-       "      <td>17.540000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table><p>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "TrainOutput(global_step=40, training_loss=1.6924976348876952, metrics={'train_runtime': 143.6457, 'train_samples_per_second': 13.923, 'train_steps_per_second': 0.278, 'total_flos': 65203027574784.0, 'train_loss': 1.6924976348876952, 'epoch': 10.0})"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "model = AutoModelForSeq2SeqLM.from_pretrained(checkpoint).to(device)\n",
-    "data_collator = DataCollatorForSeq2Seq(tokenizer=tokenizer, model=checkpoint)\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(\n",
+    "    checkpoint,\n",
+    "    num_labels=num_labels,\n",
+    "    id2label=id2label,\n",
+    "    label2id=label2id,\n",
+    ").to(device)\n",
     "\n",
-    "trainer = Seq2SeqTrainer(\n",
+    "trainer = Trainer(\n",
     "    model=model,\n",
     "    args=training_args,\n",
-    "    train_dataset=tokenized_books[\"train\"].select(range(200)), # we only select a small subsample for demonstration purposes\n",
-    "    eval_dataset=tokenized_books[\"test\"].select(range(50)), # we only select a small subsample for demonstration purposes\n",
-    "    tokenizer=tokenizer, \n",
+    "    train_dataset=tokenized_emotion[\"train\"].select(range(200)),    # small subsample for demonstration\n",
+    "    eval_dataset=tokenized_emotion[\"validation\"].select(range(50)),  # small subsample for demonstration\n",
+    "    processing_class=tokenizer,\n",
     "    data_collator=data_collator,\n",
     "    compute_metrics=compute_metrics,\n",
     ")\n",
     "\n",
     "trainer.train()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load the fully fine-tuned model\n",
+    "\n",
+    "The demonstration above only fine-tunes on a small subsample, so its predictions are not yet reliable.\n",
+    "Fully fine-tuning DistilBERT on the complete emotion dataset takes ~20 minutes, so we provide the resulting weights as a downloadable asset.\n",
+    "The cell below loads them - reusing a local copy in `../data/` if one is already present, otherwise downloading it - and the rest of the tutorials use this fine-tuned model.\n",
+    "\n",
+    "*The training script and metrics for these weights are in [`distilbert-emotion-training/`](./distilbert-emotion-training).*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import os\n",
+    "import zipfile\n",
+    "import requests\n",
+    "\n",
+    "# Fine-tuned DistilBERT emotion weights, hosted as a GitHub Release asset.\n",
+    "# NOTE: the download link becomes active once the weights Release is published.\n",
+    "url = \"https://github.com/HelmholtzAI-Consultants-Munich/XAI-Tutorials/releases/download/distilbert-emotion-weights/distilbert_emotion_weights.zip\"\n",
+    "\n",
+    "weights_path = \"../data/distilbert-emotion\"\n",
+    "zip_path = \"../data/distilbert_emotion_weights.zip\"\n",
+    "os.makedirs(\"../data\", exist_ok=True)\n",
+    "\n",
+    "if not os.path.exists(weights_path):\n",
+    "    # Reuse a local zip if it is already there (e.g. shared for testing),\n",
+    "    # otherwise download it from the Release.\n",
+    "    if not os.path.exists(zip_path):\n",
+    "        with open(zip_path, \"wb\") as f:\n",
+    "            f.write(requests.get(url).content)\n",
+    "    with zipfile.ZipFile(zip_path, \"r\") as zip_ref:\n",
+    "        zip_ref.extractall(\"../data/\")\n",
+    "\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(weights_path).to(device)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(weights_path)"
+   ],
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {

--- a/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
+++ b/xai-for-transformer/1-Tutorial_Transformer_Model.ipynb
@@ -146,40 +146,12 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Motivation\n",
-    "\n",
-    "Transformers largely replaced earlier sequence models (such as recurrent neural networks): their attention mechanism processes all tokens in parallel and captures long-range relationships between them directly, which makes them both faster to train and more accurate. This architecture underpins today's large language models. The video below builds this intuition and visualizes the overall architecture.\n",
-    "\n",
-    "*Watch: [Transformer Basic – Overview](https://www.youtube.com/watch?v=aqIZG521uwE&list=PLK2tkofg74mk) · Read more: [Introduction to Transformers](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#introduction-to-transformers)*"
-   ]
+   "source": "### Overview\n\nTransformers largely replaced earlier sequence models (such as recurrent neural networks): their attention mechanism processes all tokens in parallel and captures long-range relationships between them directly, which makes them both faster to train and more accurate. This architecture underpins today's large language models. The video below builds this intuition and visualizes the overall architecture.\n\n*Watch: [Transformer Basic – Overview](https://www.youtube.com/watch?v=aqIZG521uwE&list=PLK2tkofg74mk) · Read more: [Introduction to Transformers](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#introduction-to-transformers)*"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Input Processing\n",
-    "\n",
-    "Before an input sequence can be processed by a transformer model, it undergoes several preprocessing steps: \n",
-    "\n",
-    "- **Tokenization:** is a fundamental step in Natural Language Processing (NLP). It involves splitting text into smaller units called tokens. Depending on the tokenization strategy, tokens can be words, subwords, characters or even an entire sentence.\n",
-    "\n",
-    "  Example:  \n",
-    "  Text: \"Natural Language Processing is fascinating.\"  \n",
-    "  Tokens: [\"Natural\", \"Language\", \"Processing\", \"is\", \"fascinating\"]  \n",
-    "  *TODO: add line of code* \n",
-    "\n",
-    "- **Input Embeddings:** After tokenization, each token is converted into a high-dimensional vector representation called embedding. These embeddings capture semantic relationships between tokens and serve as numerical input to the transformer.\n",
-    "\n",
-    "    *TODO: add line of code*\n",
-    "\n",
-    "    *Watch: [Transformer Basic – Word Embedding](https://www.youtube.com/watch?v=Z7K2uodMnts&list=PLK2tkofg74mk) · Read more: [Word embedding](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#word-embedding)*\n",
-    "\n",
-    "\n",
-    "- **Positional Encodings:** Unlike recurrent or convolutional networks, transformers do not inherently capture the order of tokens in a sequence. To provide positional information, positional encodings are added to the input embeddings. These encodings have the same dimensionality as the embeddings and are typically generated using sine and cosine functions of varying frequencies. This approach assigns a unique representation to each position, enabling the model to distinguish between tokens based on their order within the sequence.\n",
-    "\n",
-    "    *Watch: [Transformer Basic – Positional Encoding](https://www.youtube.com/watch?v=1s_XUBB1RsY&list=PLK2tkofg74mk) · Read more: [Positional encoding](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#positional-encoding)*"
-   ]
+   "source": "### Input Processing\n\nBefore an input sequence can be processed by a transformer model, it undergoes several preprocessing steps:\n\n#### Tokenization\n\nTokenization is a fundamental step in Natural Language Processing (NLP). It involves splitting text into smaller units called tokens. Depending on the tokenization strategy, tokens can be words, subwords, characters or even an entire sentence.\n\nExample:  \nText: \"Natural Language Processing is fascinating.\"  \nTokens: [\"Natural\", \"Language\", \"Processing\", \"is\", \"fascinating\"]  \n*TODO: add line of code*\n\n#### Word Embedding\n\nAfter tokenization, each token is converted into a high-dimensional vector representation called embedding. These embeddings capture semantic relationships between tokens and serve as numerical input to the transformer.\n\n*TODO: add line of code*\n\n*Watch: [Transformer Basic – Word Embedding](https://www.youtube.com/watch?v=Z7K2uodMnts&list=PLK2tkofg74mk) · Read more: [Word embedding](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#word-embedding)*\n\n#### Positional Encoding\n\nUnlike recurrent or convolutional networks, transformers do not inherently capture the order of tokens in a sequence. To provide positional information, positional encodings are added to the input embeddings. These encodings have the same dimensionality as the embeddings and are typically generated using sine and cosine functions of varying frequencies. This approach assigns a unique representation to each position, enabling the model to distinguish between tokens based on their order within the sequence.\n\n*Watch: [Transformer Basic – Positional Encoding](https://www.youtube.com/watch?v=1s_XUBB1RsY&list=PLK2tkofg74mk) · Read more: [Positional encoding](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#positional-encoding)*"
   },
   {
    "cell_type": "code",
@@ -209,25 +181,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Multi Head Attention\n",
-    "\n",
-    "The Multi-Head Attention mechanism enables the Transformer to model relationships between different positions in a sequence. Instead of relying on a single attention operation, it uses multiple attention heads, each of which can focus on different aspects of the input and learn distinct patterns or dependencies.\n",
-    "\n",
-    "Within each attention head, Scaled Dot-Product Attention is computed. The outputs of all attention heads are then concatenated and passed through a linear transformation to produce the final output representation.\n",
-    "\n",
-    "Before diving into the implementation, it is helpful to first develop an intuitive understanding of the attention mechanism. The following video provides a clear explanation of how attention works and why it is a key component of Transformer models:\n",
-    "\n",
-    "Attention Mechanism Explained: *Watch: [Transformer Basic – Self Attention](https://www.youtube.com/watch?v=6njflIo3BHI&list=PLK2tkofg74mk) · Read more: [Self-attention](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#self-attention)*\n",
-    "\n",
-    "For a deeper understanding of the attention mechanisms used in the Transformer decoder, including Masked Self-Attention and Cross-Attention, you can also watch: (TODO: I would rather mention this after with the decoder part)\n",
-    "\n",
-    "Attention in the Decoder (Masked and Cross-Attention): *Watch: [Transformer Basic – Masked and Cross Attention](https://www.youtube.com/watch?v=NONly4i_-3Q&list=PLK2tkofg74mk) · Read more: [Masked self-attention and cross-attention](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#masked-self-attention-and-cross-attention)*\n",
-    "\n",
-    "Multi-Head Attention: *Watch: [Transformer Basic – Multi-Head Attention](https://www.youtube.com/watch?v=99100CbBsck&list=PLK2tkofg74mk) · Read more: [Multi head attention](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#multi-head-attention)*\n",
-    "\n",
-    "After reviewing these concepts, we will examine the code implementation of Multi-Head Attention in more detail."
-   ]
+   "source": "### Attention\n\nThe attention mechanism is the key component of Transformer models: it lets the model relate different positions in a sequence, so that each token's representation can be informed by the other tokens most relevant to it. Before diving into the implementation, it helps to build an intuition for how attention works.\n\n#### Self-Attention\n\nWithin a single attention head, **Scaled Dot-Product Attention** is computed: for every token, the model measures how much it should attend to each other token in the same sequence, and uses those weights to form a context-aware representation of the token.\n\n*Watch: [Transformer Basic – Self Attention](https://www.youtube.com/watch?v=6njflIo3BHI&list=PLK2tkofg74mk) · Read more: [Self-attention](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#self-attention)*\n\n#### Multi-Head Attention\n\nInstead of relying on a single attention operation, Multi-Head Attention uses multiple attention heads, each of which can focus on different aspects of the input and learn distinct patterns or dependencies. The outputs of all attention heads are then concatenated and passed through a linear transformation to produce the final output representation. After reviewing this concept, we will examine the code implementation of Multi-Head Attention in more detail.\n\n*Watch: [Transformer Basic – Multi-Head Attention](https://www.youtube.com/watch?v=99100CbBsck&list=PLK2tkofg74mk) · Read more: [Multi head attention](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#multi-head-attention)*"
   },
   {
    "cell_type": "code",
@@ -294,23 +248,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Putting It All Together\n",
-    "\n",
-    "The original Transformer has two components, an **encoder** and a **decoder**. Modern models often use only one, depending on the task. Since this course focuses on text *classification*, we will use the **encoder** only.\n",
-    "\n",
-    "*Watch: [Transformer Basic – Putting it all together](https://www.youtube.com/watch?v=SE6CH0plnW0&list=PLK2tkofg74mk) · Read more: [Putting them all together](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#putting-them-all-together)*\n",
-    "\n",
-    "#### Encoder\n",
-    "\n",
-    "The encoder turns the input sequence into a contextualized representation that captures the relationships between tokens. It is a stack of identical layers — the original Transformer uses six — each containing:\n",
-    "\n",
-    "* **Multi-Head Self-Attention**, which lets each token attend to all other tokens in the sequence.\n",
-    "* **Feed-Forward Network**, which refines each token's representation independently, applying two linear transformations with a ReLU activation in between.\n",
-    "* **Residual Connections and Layer Normalization**, which stabilize training and help information flow.\n",
-    "\n",
-    "The final layer outputs a sequence of vectors that encodes the meaning and context of the input, ready for a downstream task such as classification."
-   ]
+   "source": "### Putting it all together\n\nThe original Transformer has two components, an **encoder** and a **decoder**. Modern models often use only one, depending on the task. Since this course focuses on text *classification*, we will use the **encoder** only.\n\n*Watch: [Transformer Basic – Putting it all together](https://www.youtube.com/watch?v=SE6CH0plnW0&list=PLK2tkofg74mk) · Read more: [Putting them all together](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#putting-them-all-together)*\n\n#### Encoder\n\nThe encoder turns the input sequence into a contextualized representation that captures the relationships between tokens. It is a stack of identical layers — the original Transformer uses six — each containing:\n\n* **Multi-Head Self-Attention**, which lets each token attend to all other tokens in the sequence.\n* **Feed-Forward Network**, which refines each token's representation independently, applying two linear transformations with a ReLU activation in between.\n* **Residual Connections and Layer Normalization**, which stabilize training and help information flow.\n\nThe final layer outputs a sequence of vectors that encodes the meaning and context of the input, ready for a downstream task such as classification."
   },
   {
    "cell_type": "code",
@@ -350,15 +288,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "#### Decoder\n",
-    "\n",
-    "The **decoder** generates an output sequence one token at a time, using masked self-attention (so a token cannot attend to future positions) and cross-attention over the encoder's output. It is mainly used for sequence-generation tasks such as machine translation.\n",
-    "\n",
-    "Since this course focuses on understanding and classifying text, **we do not use the decoder here.** Its full implementation, together with a machine-translation fine-tuning example, is covered in the companion notebook:\n",
-    "\n",
-    "[*1-Tutorial_Transformer_Model-Translation.ipynb*](./1-Tutorial_Transformer_Model-Translation.ipynb)"
-   ]
+   "source": "#### Decoder\n\nThe **decoder** generates an output sequence one token at a time, using **masked self-attention** (so a token cannot attend to future positions) and **cross-attention** over the encoder's output. It is mainly used for sequence-generation tasks such as machine translation.\n\n*Watch: [Transformer Basic – Masked and Cross Attention](https://www.youtube.com/watch?v=NONly4i_-3Q&list=PLK2tkofg74mk) · Read more: [Masked self-attention and cross-attention](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#masked-self-attention-and-cross-attention)*\n\nSince this course focuses on understanding and classifying text, **we do not use the decoder here.** Its full implementation, together with a machine-translation fine-tuning example, is covered in the companion notebook:\n\n[*1-Tutorial_Transformer_Model-Translation.ipynb*](./1-Tutorial_Transformer_Model-Translation.ipynb)"
   },
   {
    "cell_type": "markdown",

--- a/xai-for-transformer/Old-1-Tutorial_Transformer_Model.ipynb
+++ b/xai-for-transformer/Old-1-Tutorial_Transformer_Model.ipynb
@@ -96,20 +96,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "import math\n",
+    "import evaluate\n",
     "\n",
     "import torch\n",
     "import torch.nn as nn\n",
     "\n",
     "import numpy as np\n",
     "\n",
+    "from datasets import load_dataset\n",
     "from transformers import (\n",
     "    AutoTokenizer,\n",
-    "    AutoModelForSequenceClassification,\n",
+    "    DataCollatorForSeq2Seq,\n",
+    "    AutoModelForSeq2SeqLM,\n",
+    "    Seq2SeqTrainingArguments,\n",
+    "    Seq2SeqTrainer,\n",
     ")\n",
     "\n",
     "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")"
@@ -128,19 +133,11 @@
    "source": [
     "## Build a Transformer Model\n",
     "\n",
-    "In the subsequent sections we will show you how to build a transformer architecture using PyTorch, we alternate a step-by-step implementaion with a small video explanation of the specific component.\n",
+    "**Please visit our [Introduction to Transformers](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html) to get more theoretical background information on the Transformer architecture.**\n",
     "\n",
-    "***Note: we provide all references [here](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#references).***"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Motivation\n",
-    "Let's start with an introduction to the reason why transofmers became so popular and a visualization of the whole architecture\n",
+    "***Note: we provide all references [here](https://xai-tutorials.readthedocs.io/en/latest/_ml_basics/transformer.html#references).***\n",
     "\n",
-    "*TODO: Add video 1*"
+    "In the subsequent sections we will show you how to build a transformer architecture using PyTorch."
    ]
   },
   {
@@ -149,28 +146,23 @@
    "source": [
     "### Input Processing\n",
     "\n",
-    "Before an input sequence can be processed by a transformer model, it undergoes several preprocessing steps: \n",
+    "Before feeding the input into the transformer model, certain steps have to be performed: \n",
     "\n",
-    "- **Tokenization:** is a fundamental step in NLP. It involves splitting text into smaller units called tokens. Depending on the tokenization strategy, tokens can be words, subwords, characters or even an entire sentence.\n",
+    "- **Tokenization:** is a fundamental step in NLP. It involves splitting text into smaller units called tokens. Tokens are often words, but they can also be characters, subwords, or even sentences, depending on the level of tokenization.  \n",
+    "Example:  \n",
+    "Text: \"Natural Language Processing is fascinating.\"  \n",
+    "Tokens: [\"Natural\", \"Language\", \"Processing\", \"is\", \"fascinating\"]  \n",
     "\n",
-    "  Example:  \n",
-    "  Text: \"Natural Language Processing is fascinating.\"  \n",
-    "  Tokens: [\"Natural\", \"Language\", \"Processing\", \"is\", \"fascinating\"]  \n",
-    "  *TODO: add line of code* \n",
+    "- **Input Embeddings:** The input sequence (e.g., a sentence) is converted into a sequence of vectors. This is done through embeddings which map words or tokens to high-dimensional vectors.\n",
     "\n",
-    "- **Input Embeddings:** After tokenization, each token is converted into a  high-dimensional vector representation called embedding. These embeddings wcapture semantic relationshios between tokens and serve as numerical input to the transformer.\n",
-    "\n",
-    "    *TODO: add line of code + add video 2*\n",
-    "\n",
-    "\n",
-    "- **Positional Encodings:** Unlike recurrent or convolutional network, transformers do not inherently capture the order of tokens in a sequence. To provide positional information, positional encodings are added to the input embeddings. These encodings have the same dimensionality as the embeddings and are typically generated using sine and cosine functions of varying frequencies. This approach assigns a unique representation to each position, enabling the model to distinguish between tokens based on their order within the sequence.\n",
-    "\n",
-    "    *TODO: add video 3*"
+    "- **Positional Encodings:** Since the Transformer does not have recurrent or convolutional layers, it uses positional encodings to add information about the position of each token in the sequence.  \n",
+    "These positional encodings have the same dimension as the embeddings and are added to them. The alternating sine and cosine functions ensure that each position in the sequence is represented by a unique  \n",
+    "combination of values, allowing the model to distinguish between different positions effectively."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,24 +191,13 @@
    "source": [
     "### Multi Head Attention\n",
     "\n",
-    "The Multi-Head Attention mechanism enables the Transformer to model relationships between different positions in a sequence. Instead of relying on a single attention operation, it uses multiple attention heads, each of which can focus on different aspects of the input and learn distinct patterns or dependencies.\n",
-    "\n",
-    "Within each attention head, Scaled Dot-Product Attention is computed. The outputs of all attention heads are then concatenated and passed through a linear transformation to produce the final output representation.\n",
-    "\n",
-    "Before diving into the implementation, it is helpful to first develop an intuitive understanding of the attention mechanism. The following video provides a clear explanation of how attention works and why it is a key component of Transformer models:\n",
-    "\n",
-    "Attention Mechanism Explained: *TODO: Insert video link*\n",
-    "\n",
-    "For a deeper understanding of the attention mechanisms used in the Transformer decoder, including Masked Self-Attention and Cross-Attention, you can also watch: (TODO: I would rather mention this after with the decoder part)\n",
-    "\n",
-    "Attention in the Decoder (Masked and Cross-Attention): *TODO: Insert video link*\n",
-    "\n",
-    "After reviewing these concepts, we will examine the code implementation of Multi-Head Attention in more detail."
+    "The Multi-Head Attention mechanism computes the attention between each pair of positions in a sequence. It consists of multiple “attention heads” that capture different aspects of the input sequence.  \n",
+    "In each attention head the scaled dot-prduct attention is calculated. The outputs of all attention heads are concatenated and then linearly transformed into the final output."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,28 +261,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Putting It All Together\n",
+    "### Encoder Part\n",
     "\n",
-    "The original Transformer architecture consists of two main components: an **encoder** and a **decoder**. While many modern Transformer-based models use only one of these components, depending on the task they are designed to perform, it is useful to first understand the complete architecture before exploring specific applications.\n",
+    "The encoder in the Transformer architecture is designed to process and encode input sequences. It is a critical component for understanding and representing the input data in a form that the decoder can then use for tasks like translation or text generation. \n",
+    "The encoder part is composed of:\n",
     "\n",
-    "*TODO: add video*\n",
+    "- **Stack of Layers:** The encoder is composed of a stack of identical layers. The number of layers varies (e.g., the original Transformer model uses 6 layers), but each layer has the same structure.\n",
+    "- **Each Encoder Layer  is composed of:**\n",
+    "  - A multi-head self-attention mechanism.\n",
+    "  - A position-wise fully connected feed-forward network: The position-wise feed-forward network applies two linear transformations with a ReLU activation in between each position individually. This component complements self-attention by processing each element (word or token) of the sequence independently, enriching the representation with individual element-level information.\n",
+    "  - Normalization and Residual Connections: After each sub-component (the self-attention and the feed-forward network), there is a process of normalization. Also, each sub-component has a residual connection around it. This means the output of each sub-component is added to its input, and then normalized. These features help in training deep networks.\n",
     "\n",
-    "#### Encoder\n",
-    "\n",
-    "The encoder processes the input sequence and transforms it into a contextualized representation that captures the relationships between tokens.\n",
-    "\n",
-    "It is composed of a stack of identical layers, each containing:\n",
-    "\n",
-    "* Multi-Head Self-Attention, which allows each token to attend to all other tokens in the sequence.\n",
-    "* Feed-Forward Network, which independently refines the representation of each token.\n",
-    "* Residual Connections and Layer Normalization, which improve training stability and help information flow through the network.\n",
-    "\n",
-    "The output of the final encoder layer is a sequence of vectors that encodes the meaning and context of the input sequence. This representation can then be used by the decoder or by downstream tasks.\n"
+    "The output of the final encoder layer is a sequence of vectors representing the input sequence. This output is then used as the input for the Transformer decoder."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,43 +314,67 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Decoder\n",
+    "### Decoder Part\n",
     "\n",
-    "The decoder generates the output sequence one token at a time based on the encoded input and previously generated tokens.\n",
+    "In the Transformer model, the decoder is structured similarly to the encoder but with key differences for output generation tasks like machine translation and text summarization:\n",
     "\n",
-    "Each decoder layer contains:\n",
+    "- **Structure:** It consists of multiple layers, each with two types of multi-head attention mechanisms (self-attention and encoder-decoder attention) and a feed-forward neural network.\n",
     "\n",
-    "* Masked Multi-Head Self-Attention, which prevents tokens from attending to future positions.\n",
-    "* Encoder-Decoder Attention (Cross-Attention), which allows the decoder to focus on relevant parts of the encoder output.\n",
-    "* Feed-Forward Network, which further processes the token representations.\n",
-    "* Residual Connections and Layer Normalization, which improve training stability.\n",
+    "- **Input Processing:** The input to the decoder is the right-shifted target sequence, ensuring each position's prediction is based only on preceding elements.\n",
     "\n",
-    "The final decoder output is passed through a linear layer and a softmax function to produce probabilities over the vocabulary and generate the next token in the sequence.\n",
+    "- **Masked Self-Attention:** This prevents the decoder from accessing future positions in the sequence, which is crucial for maintaining sequential dependency.\n",
     "\n",
-    "In this course, we focus on Transformer models for understanding and classifying text. Therefore, we will mainly work with encoder-based architectures (e.g., BERT) and will not use the decoder component, which is primarily designed for sequence generation tasks such as machine translation and text generation.\n",
+    "- **Encoder-Decoder Attention:** Each layer in the decoder focuses on relevant parts of the encoder output, which is crucial for aligning the input and output sequences in tasks like translation.\n",
     "\n",
-    "If you are interested in the implementation details and the fine-tuning process for a machine translation task, please refer to the accompanying notebook:\n",
+    "- **Output Generation:** The decoder's top layer output goes through a linear layer and a softmax to generate word probabilities for the sequence.\n",
     "\n",
-    "TODO: add link to translation notebook."
+    "- **Training Mechanism:** Utilizes \"teacher forcing,\" where the actual output sequence is used as the next input, aiding in training efficiency but potentially causing exposure bias during inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the decoder layer\n",
+    "class DecoderLayer(nn.Module):\n",
+    "    def __init__(self, d_model, num_heads, d_ff, dropout):\n",
+    "        super(DecoderLayer, self).__init__()\n",
+    "        self.self_attn = MultiHeadAttention(d_model, num_heads)\n",
+    "        self.cross_attn = MultiHeadAttention(d_model, num_heads)\n",
+    "        self.feed_forward = PositionWiseFeedForward(d_model, d_ff)\n",
+    "        self.norm1 = nn.LayerNorm(d_model)\n",
+    "        self.norm2 = nn.LayerNorm(d_model)\n",
+    "        self.norm3 = nn.LayerNorm(d_model)\n",
+    "        self.dropout = nn.Dropout(dropout)\n",
+    "        \n",
+    "    def forward(self, x, enc_output, src_mask, tgt_mask):\n",
+    "        attn_output = self.self_attn(x, x, x, tgt_mask)\n",
+    "        x = self.norm1(x + self.dropout(attn_output))\n",
+    "        attn_output = self.cross_attn(x, enc_output, enc_output, src_mask)\n",
+    "        x = self.norm2(x + self.dropout(attn_output))\n",
+    "        ff_output = self.feed_forward(x)\n",
+    "        x = self.norm3(x + self.dropout(ff_output))\n",
+    "        return x"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Assemble the final Transformer Classifier\n",
+    "### Assemble the final Transformer Model\n",
     "\n",
-    "For the final Transformer classifier, we combine the positional encodings, multi-head self-attention mechanisms, and stacked encoder layers introduced above into a complete encoder-only architecture suitable for text classification.\n",
+    "For the final Transformer model we combine the positional encodings, multi-head attention mechanisms and deep encoder-decoder layers introduced above to a full Transformer model:\n",
     "\n",
-    "- **Mask generation:** An attention mask is created for the input sequence to prevent the attention mechanism from focusing on padding tokens. This ensures that only meaningful tokens contribute to the learned representations.\n",
-    "\n",
-    "- **Embedding and positional encoding:** The input tokens are mapped to dense vector representations through an embedding layer (`embedding`). A `PositionalEncoding` layer is then applied to inject positional information, enabling the model to capture the order of tokens within the sequence.\n",
-    "\n",
-    "- **Encoder layers:** The model consists of multiple encoder layers, defined by `num_layers`. Each encoder layer contains multi-head self-attention, feed-forward networks, residual connections, and layer normalization. The input embeddings are progressively transformed into contextual representations that capture relationships between all tokens in the sequence.\n",
-    "\n",
-    "- **Sequence representation and classification head:** After the encoder stack, the contextual representation of the input sequence is aggregated into a sequence-level representation. This representation is then passed through a fully connected classification head to predict the output class (e.g., positive or negative sentiment).\n",
-    "\n",
-    "> **Note:** Our simplified implementation uses the representation of the first token as a sequence-level representation. In BERT and DistilBERT, a special classification token (`[CLS]`) is prepended to every input sequence, and its final contextual representation is used by the classification head."
+    "- **Mask generation:** A mask for the src sequence is created, which prevents the attention mechanisms from focusing on padding tokens in the source sequence.  \n",
+    "A mask for the tgt sequence is created, which includes a \"no peak\" mask to prevent the model from attending to future tokens during training, enforcing autoregressive behavior.\n",
+    "- **Embedding and positional encoding:** The model includes separate embedding layers (`encoder_embedding` and `decoder_embedding`) for the source (input) and target (output) vocabularies, mapping tokens to a dense vector space of size `d_model`.  \n",
+    "A PositionalEncoding layer is applied to the embeddings to inject positional information, crucial since Transformers lack inherent sequence order awareness.\n",
+    "- **Encoder and decoder layers:** The model has multiple layers of encoders and decoders, defined by `num_layers`. Each encoder and decoder layer includes mechanisms for multi-head attention, feedforward networks, and residual connections.  \n",
+    "The source sequence embeddings are passed through a series of encoder layers, with each layer transforming the embeddings based on the input mask.  \n",
+    "The target sequence embeddings are processed through the decoder layers, using both the encoded source information and the target mask to generate context-aware embeddings.\n",
+    "- **Output layer:** The decoder's output is passed through the final linear layer to generate predictions for the next token in the sequence."
    ]
   },
   {
@@ -383,143 +383,92 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define the transformer classifier model\n",
-    "class TransformerClassifier(nn.Module):\n",
-    "    def __init__(self, vocab_size, d_model, num_heads, num_layers,\n",
-    "                 d_ff, max_seq_length, num_classes, dropout):\n",
-    "        super().__init__()\n",
-    "\n",
-    "        self.embedding = nn.Embedding(vocab_size, d_model)\n",
+    "# Define the transformer model\n",
+    "class Transformer(nn.Module):\n",
+    "    def __init__(self, src_vocab_size, tgt_vocab_size, d_model, num_heads, num_layers, d_ff, max_seq_length, dropout):\n",
+    "        super(Transformer, self).__init__()\n",
+    "        self.encoder_embedding = nn.Embedding(src_vocab_size, d_model)\n",
+    "        self.decoder_embedding = nn.Embedding(tgt_vocab_size, d_model)\n",
     "        self.positional_encoding = PositionalEncoding(d_model, max_seq_length)\n",
     "\n",
-    "        self.encoder_layers = nn.ModuleList([\n",
-    "            EncoderLayer(d_model, num_heads, d_ff, dropout)\n",
-    "            for _ in range(num_layers)\n",
-    "        ])\n",
+    "        self.encoder_layers = nn.ModuleList([EncoderLayer(d_model, num_heads, d_ff, dropout) for _ in range(num_layers)])\n",
+    "        self.decoder_layers = nn.ModuleList([DecoderLayer(d_model, num_heads, d_ff, dropout) for _ in range(num_layers)])\n",
     "\n",
-    "        self.classifier = nn.Linear(d_model, num_classes)\n",
+    "        self.fc = nn.Linear(d_model, tgt_vocab_size)\n",
     "        self.dropout = nn.Dropout(dropout)\n",
     "\n",
-    "    def generate_mask(self, input_ids):\n",
-    "        return (input_ids != 0).unsqueeze(1).unsqueeze(2)\n",
+    "    def generate_mask(self, src, tgt):\n",
+    "        src_mask = (src != 0).unsqueeze(1).unsqueeze(2)\n",
+    "        tgt_mask = (tgt != 0).unsqueeze(1).unsqueeze(3)\n",
+    "        seq_length = tgt.size(1)\n",
+    "        nopeak_mask = (1 - torch.triu(torch.ones(1, seq_length, seq_length), diagonal=1)).bool()\n",
+    "        tgt_mask = tgt_mask & nopeak_mask\n",
+    "        return src_mask, tgt_mask\n",
     "\n",
-    "    def forward(self, input_ids):\n",
-    "        mask = self.generate_mask(input_ids)\n",
+    "    def forward(self, src, tgt):\n",
+    "        src_mask, tgt_mask = self.generate_mask(src, tgt)\n",
+    "        src_embedded = self.dropout(self.positional_encoding(self.encoder_embedding(src)))\n",
+    "        tgt_embedded = self.dropout(self.positional_encoding(self.decoder_embedding(tgt)))\n",
     "\n",
-    "        x = self.embedding(input_ids)\n",
-    "        x = self.positional_encoding(x)\n",
-    "        x = self.dropout(x)\n",
+    "        enc_output = src_embedded\n",
+    "        for enc_layer in self.encoder_layers:\n",
+    "            enc_output = enc_layer(enc_output, src_mask)\n",
     "\n",
-    "        for encoder_layer in self.encoder_layers:\n",
-    "            x = encoder_layer(x, mask)\n",
+    "        dec_output = tgt_embedded\n",
+    "        for dec_layer in self.decoder_layers:\n",
+    "            dec_output = dec_layer(dec_output, enc_output, src_mask, tgt_mask)\n",
     "\n",
-    "        cls_representation = x[:, 0, :]\n",
-    "        logits = self.classifier(cls_representation)\n",
-    "\n",
-    "        return logits"
+    "        output = self.fc(dec_output)\n",
+    "        return output"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Parametrize the Transformer Classifier\n",
+    "### Parametrize the Transformer Model\n",
     "\n",
-    "To instantiate the Transformer classifier, we define the main architectural parameters that control the size and complexity of the model:\n",
-    "\n",
-    "- `vocab_size`: The size of the vocabulary, i.e., the total number of unique tokens (words or subwords) that the model can process.\n",
-    "- `d_model`: The dimensionality of the token embeddings and hidden representations throughout the model.\n",
-    "- `num_heads`: The number of attention heads used in each multi-head self-attention layer.\n",
-    "- `num_layers`: The number of stacked encoder layers.\n",
-    "- `d_ff`: The dimensionality of the hidden layer in the feed-forward network contained in each encoder layer.\n",
-    "- `max_seq_length`: The maximum input sequence length supported by the positional encoding.\n",
-    "- `num_classes`: The number of output classes for the classification task.\n",
-    "- `dropout`: The dropout probability used as a regularization technique to reduce overfitting.\n",
-    "\n",
-    "The following parameters define a small Transformer classifier for demonstration purposes."
+    "To setup the transformer model we have to define the model parameters:\n",
+    "- `src_vocab_size`: the source vocabulary contains all possible tokens (words, subwords, etc.) that the model can encounter in the input sequence.\n",
+    "- `tgt_vocab_size`: the target vocabulary contains all possible tokens that the model can generate in the output sequence.\n",
+    "- `d_model`: the dimensionality of the model's embeddings and hidden layers. Each token in the source and target sequences will be represented by a `d_model`-dimensional vector.\n",
+    "- `num_heads`: the number of attention heads in the multi-head attention mechanism. \n",
+    "- `num_layers`: the number of layers in both the encoder and decoder.\n",
+    "- `d_ff`: the dimensionality of the feedforward network hidden layer within each encoder and decoder layer.\n",
+    "- `max_seq_length`: the maximum length of input and output sequences that the model can handle. Positional encodings will be computed up to this sequence length.\n",
+    "- `dropout`: the dropout rate is a regularization technique used to prevent overfitting by randomly setting a fraction of the input units to zero during training."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "vocab_size = 5000\n",
+    "src_vocab_size = 5000\n",
+    "tgt_vocab_size = 5000\n",
     "d_model = 512\n",
     "num_heads = 8\n",
     "num_layers = 6\n",
     "d_ff = 2048\n",
     "max_seq_length = 100\n",
-    "num_classes = 2\n",
-    "dropout = 0.1\n"
+    "dropout = 0.1"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "transformer_classifier = TransformerClassifier(\n",
-    "    vocab_size,\n",
-    "    d_model,\n",
-    "    num_heads,\n",
-    "    num_layers,\n",
-    "    d_ff,\n",
-    "    max_seq_length,\n",
-    "    num_classes,\n",
-    "    dropout\n",
-    ").to(device)"
+    "transformer = Transformer(src_vocab_size, tgt_vocab_size, d_model, num_heads, num_layers, d_ff, max_seq_length, dropout).to(device)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## BERT\n",
-    "\n",
-    "The previous sections introduced the original Transformer architecture and demonstrated how its main components can be assembled into an encoder-only Transformer classifier.\n",
-    "\n",
-    "In practice, however, modern Natural Language Processing (NLP) applications rarely train Transformer models from scratch. Instead, they rely on **pretrained language models**, which are first trained on large text corpora and later adapted to specific downstream tasks through fine-tuning.\n",
-    "\n",
-    "One of the most influential encoder-only Transformer models is **BERT (Bidirectional Encoder Representations from Transformers)**. Unlike the original encoder-decoder Transformer, BERT consists only of the encoder stack and is designed to learn contextual representations of text by attending to both the left and right context of every token simultaneously.\n",
-    "\n",
-    "*TODO: add video*\n",
-    "\n",
-    "In this course, we will use **DistilBERT**, a lightweight version of BERT that retains most of its performance while requiring fewer parameters and less computational resources. This makes it particularly suitable for educational purposes and explainability analyses.\n",
-    "\n",
-    "*TODO: consider adding a table to show dofference between BERT and DistillBERT in readthedocs?*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Loading a pretrained DistilBERT model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "checkpoint = \"distilbert-base-uncased\"\n",
-    "\n",
-    "tokenizer = AutoTokenizer.from_pretrained(checkpoint)\n",
-    "model = AutoModelForSequenceClassification.from_pretrained(\n",
-    "    checkpoint,\n",
-    "    num_labels=6\n",
-    "    ).to(device)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Extra Material: Finetune a Transformer Model (TODO: update for classification task)\n",
+    "## Finetune a Transformer Model \n",
     "\n",
     "In the subsequent sections we will show you how to fine-tune a transformer model using a pre-trained model from [Huggingface](https://huggingface.co/docs/transformers/index)."
    ]
@@ -867,7 +816,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,

--- a/xai-for-transformer/distilbert-emotion-training/README.md
+++ b/xai-for-transformer/distilbert-emotion-training/README.md
@@ -1,0 +1,47 @@
+# DistilBERT emotion — training
+
+This folder documents how the **DistilBERT emotion classifier** used in the transformer
+tutorials was produced. The trained weights themselves are **not** stored here (~268 MB) —
+they are published as a GitHub **Release asset** (`distilbert_emotion_weights.zip`) and
+downloaded by the tutorial notebook at runtime.
+
+## What's here
+
+| File | Description |
+|---|---|
+| `train_distilbert-emotion.py` | The fine-tuning script (`distilbert-base-uncased` → `dair-ai/emotion`). |
+| `requirements.txt` | Exact package versions used for training (Python 3.11.7). |
+| `metrics.json` | Machine-readable config + validation/test metrics. |
+| `TRAINING_SUMMARY.md` | Human-readable summary of the setup and results. |
+| `train.log` | Training console output (tqdm progress bars stripped for readability). |
+
+## The model
+
+- **Base:** `distilbert-base-uncased`
+- **Dataset:** [`dair-ai/emotion`](https://huggingface.co/datasets/dair-ai/emotion) (`split`) — 6 classes: sadness, joy, love, anger, fear, surprise
+- **Result:** test accuracy **92.95%**, weighted F1 **0.929**
+
+See [`TRAINING_SUMMARY.md`](./TRAINING_SUMMARY.md) for the full breakdown.
+
+## Reproduce
+
+```bash
+pip install -r requirements.txt
+python train_distilbert-emotion.py          # full run (~21 min on Apple Silicon / MPS)
+SMOKE=1 python train_distilbert-emotion.py  # tiny end-to-end sanity run
+```
+
+The script writes the fine-tuned checkpoint to `./distilbert-emotion/` (a standard
+`save_pretrained` folder: `config.json` + `model.safetensors` + tokenizer) and the
+metrics to `metrics.json`.
+
+## Using the weights
+
+After downloading and unzipping the Release asset, load it like any Hugging Face model:
+
+```python
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+model = AutoModelForSequenceClassification.from_pretrained("<unzipped-folder>")
+tokenizer = AutoTokenizer.from_pretrained("<unzipped-folder>")
+```

--- a/xai-for-transformer/distilbert-emotion-training/TRAINING_SUMMARY.md
+++ b/xai-for-transformer/distilbert-emotion-training/TRAINING_SUMMARY.md
@@ -1,0 +1,32 @@
+# DistilBERT fine-tuned on the Emotion dataset
+
+Checkpoint used by the XAI transformer tutorials.
+
+## Setup
+- **Base model:** `distilbert-base-uncased`
+- **Dataset:** [`dair-ai/emotion`](https://huggingface.co/datasets/dair-ai/emotion) (`split` config) — 16,000 train / 2,000 validation / 2,000 test
+- **Labels (6):** sadness, joy, love, anger, fear, surprise
+- **Hyperparameters:** 3 epochs · batch size 16 · lr 2e-5 · weight decay 0.01 · max_length 128 · seed 42
+- **Hardware:** Apple Silicon GPU (MPS), fp32 · training time ≈ 21 min
+
+## Results
+
+| Split | Accuracy | F1 (weighted) | Loss |
+|---|---|---|---|
+| Validation — epoch 1 | 0.9265 | 0.9265 | 0.1906 |
+| Validation — epoch 2 | 0.9355 | 0.9349 | 0.1678 |
+| Validation — epoch 3 | 0.9390 | 0.9391 | 0.1552 |
+| **Test (final)** | **0.9295** | **0.9290** | 0.1871 |
+
+Final training loss: 0.239.
+
+## Artifact
+- `model.safetensors` ≈ 268 MB (255 MiB), fp32
+- Load with `AutoModelForSequenceClassification.from_pretrained("<path>")`
+
+## Reproduce
+```bash
+pip install -r requirements.txt
+python train_distilbert-emotion.py          # full run
+SMOKE=1 python train_distilbert-emotion.py  # tiny sanity run
+```

--- a/xai-for-transformer/distilbert-emotion-training/metrics.json
+++ b/xai-for-transformer/distilbert-emotion-training/metrics.json
@@ -1,0 +1,44 @@
+{
+  "model": "distilbert-base-uncased",
+  "task": "sequence classification (emotion, 6 classes)",
+  "dataset": {
+    "name": "dair-ai/emotion",
+    "config": "split",
+    "n_train": 16000,
+    "n_validation": 2000,
+    "n_test": 2000,
+    "labels": ["sadness", "joy", "love", "anger", "fear", "surprise"]
+  },
+  "hyperparameters": {
+    "epochs": 3,
+    "per_device_train_batch_size": 16,
+    "per_device_eval_batch_size": 32,
+    "learning_rate": 2e-05,
+    "weight_decay": 0.01,
+    "max_length": 128,
+    "seed": 42,
+    "device": "mps",
+    "precision": "fp32"
+  },
+  "training": {
+    "train_runtime_sec": 1270,
+    "train_runtime_min": 21.2,
+    "final_train_loss": 0.239
+  },
+  "validation_per_epoch": [
+    { "epoch": 1, "loss": 0.1906, "accuracy": 0.9265, "f1_weighted": 0.9265 },
+    { "epoch": 2, "loss": 0.1678, "accuracy": 0.9355, "f1_weighted": 0.9349 },
+    { "epoch": 3, "loss": 0.1552, "accuracy": 0.9390, "f1_weighted": 0.9391 }
+  ],
+  "test": {
+    "loss": 0.1871,
+    "accuracy": 0.9295,
+    "f1_weighted": 0.9290
+  },
+  "artifact": {
+    "file": "model.safetensors",
+    "size_bytes": 267844872,
+    "size_mib": 255,
+    "dtype": "float32"
+  }
+}

--- a/xai-for-transformer/distilbert-emotion-training/requirements.txt
+++ b/xai-for-transformer/distilbert-emotion-training/requirements.txt
@@ -1,0 +1,8 @@
+# Exact package versions used to fine-tune the DistilBERT emotion checkpoint.
+# Python 3.11.7.  Install with:  pip install -r requirements.txt
+transformers==5.13.0
+datasets==5.0.0
+torch==2.6.0
+scikit-learn==1.9.0
+numpy==2.0.2
+accelerate==1.14.0

--- a/xai-for-transformer/distilbert-emotion-training/train.log
+++ b/xai-for-transformer/distilbert-emotion-training/train.log
@@ -1,0 +1,82 @@
+>> loading dataset dair-ai/emotion (split)  [SMOKE=False]
+Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
+>> labels: ['sadness', 'joy', 'love', 'anger', 'fear', 'surprise']
+[transformers] DistilBertForSequenceClassification LOAD REPORT from: distilbert-base-uncased
+Key                     | Status     | 
+------------------------+------------+-
+vocab_layer_norm.bias   | UNEXPECTED | 
+vocab_transform.bias    | UNEXPECTED | 
+vocab_transform.weight  | UNEXPECTED | 
+vocab_layer_norm.weight | UNEXPECTED | 
+vocab_projector.bias    | UNEXPECTED | 
+classifier.weight       | MISSING    | 
+classifier.bias         | MISSING    | 
+pre_classifier.bias     | MISSING    | 
+pre_classifier.weight   | MISSING    | 
+Notes:
+- UNEXPECTED:	can be ignored when loading from different task/architecture; not ok if you expect identical arch.
+- MISSING:	those params were newly initialized because missing from the checkpoint. Consider training on your downstream task.
+>> device=mps  epochs=3  train=16000
+{'loss': '1.327', 'grad_norm': '5.283', 'learning_rate': '1.934e-05', 'epoch': '0.1'}
+{'loss': '0.9739', 'grad_norm': '8.037', 'learning_rate': '1.901e-05', 'epoch': '0.15'}
+{'loss': '0.6998', 'grad_norm': '7.207', 'learning_rate': '1.867e-05', 'epoch': '0.2'}
+{'loss': '0.5744', 'grad_norm': '11.23', 'learning_rate': '1.834e-05', 'epoch': '0.25'}
+{'loss': '0.4387', 'grad_norm': '7.691', 'learning_rate': '1.801e-05', 'epoch': '0.3'}
+{'loss': '0.417', 'grad_norm': '3.789', 'learning_rate': '1.767e-05', 'epoch': '0.35'}
+{'loss': '0.3464', 'grad_norm': '13.34', 'learning_rate': '1.734e-05', 'epoch': '0.4'}
+{'loss': '0.2997', 'grad_norm': '7.362', 'learning_rate': '1.701e-05', 'epoch': '0.45'}
+{'loss': '0.2681', 'grad_norm': '5.126', 'learning_rate': '1.667e-05', 'epoch': '0.5'}
+{'loss': '0.2823', 'grad_norm': '0.8241', 'learning_rate': '1.634e-05', 'epoch': '0.55'}
+{'loss': '0.236', 'grad_norm': '21.51', 'learning_rate': '1.601e-05', 'epoch': '0.6'}
+{'loss': '0.32', 'grad_norm': '8.095', 'learning_rate': '1.567e-05', 'epoch': '0.65'}
+{'loss': '0.2115', 'grad_norm': '14.69', 'learning_rate': '1.534e-05', 'epoch': '0.7'}
+{'loss': '0.2473', 'grad_norm': '21.17', 'learning_rate': '1.501e-05', 'epoch': '0.75'}
+{'loss': '0.2201', 'grad_norm': '4.64', 'learning_rate': '1.467e-05', 'epoch': '0.8'}
+{'loss': '0.2641', 'grad_norm': '4.702', 'learning_rate': '1.434e-05', 'epoch': '0.85'}
+{'loss': '0.1823', 'grad_norm': '11.27', 'learning_rate': '1.401e-05', 'epoch': '0.9'}
+{'loss': '0.2518', 'grad_norm': '17.24', 'learning_rate': '1.367e-05', 'epoch': '0.95'}
+{'loss': '0.2101', 'grad_norm': '14.1', 'learning_rate': '1.334e-05', 'epoch': '1'}
+{'loss': '0.1287', 'grad_norm': '6.177', 'learning_rate': '1.301e-05', 'epoch': '1.05'}
+{'loss': '0.1195', 'grad_norm': '0.2473', 'learning_rate': '1.267e-05', 'epoch': '1.1'}
+{'loss': '0.1695', 'grad_norm': '7.129', 'learning_rate': '1.234e-05', 'epoch': '1.15'}
+{'loss': '0.1836', 'grad_norm': '8.66', 'learning_rate': '1.201e-05', 'epoch': '1.2'}
+{'loss': '0.147', 'grad_norm': '0.3967', 'learning_rate': '1.167e-05', 'epoch': '1.25'}
+{'loss': '0.1576', 'grad_norm': '1.533', 'learning_rate': '1.134e-05', 'epoch': '1.3'}
+{'loss': '0.1256', 'grad_norm': '2.991', 'learning_rate': '1.101e-05', 'epoch': '1.35'}
+{'loss': '0.1694', 'grad_norm': '10.15', 'learning_rate': '1.067e-05', 'epoch': '1.4'}
+{'loss': '0.1321', 'grad_norm': '5.577', 'learning_rate': '1.034e-05', 'epoch': '1.45'}
+{'loss': '0.154', 'grad_norm': '0.3539', 'learning_rate': '1.001e-05', 'epoch': '1.5'}
+{'loss': '0.1324', 'grad_norm': '0.214', 'learning_rate': '9.673e-06', 'epoch': '1.55'}
+{'loss': '0.1248', 'grad_norm': '4.918', 'learning_rate': '9.34e-06', 'epoch': '1.6'}
+{'loss': '0.1455', 'grad_norm': '5.53', 'learning_rate': '9.007e-06', 'epoch': '1.65'}
+{'loss': '0.1594', 'grad_norm': '8.761', 'learning_rate': '8.673e-06', 'epoch': '1.7'}
+{'loss': '0.1696', 'grad_norm': '0.3018', 'learning_rate': '8.34e-06', 'epoch': '1.75'}
+{'loss': '0.1469', 'grad_norm': '4.909', 'learning_rate': '8.007e-06', 'epoch': '1.8'}
+{'loss': '0.1899', 'grad_norm': '6.267', 'learning_rate': '7.673e-06', 'epoch': '1.85'}
+{'loss': '0.1364', 'grad_norm': '3.318', 'learning_rate': '7.34e-06', 'epoch': '1.9'}
+{'loss': '0.1037', 'grad_norm': '3.732', 'learning_rate': '7.007e-06', 'epoch': '1.95'}
+{'loss': '0.1501', 'grad_norm': '10.25', 'learning_rate': '6.673e-06', 'epoch': '2'}
+{'loss': '0.125', 'grad_norm': '0.1553', 'learning_rate': '6.34e-06', 'epoch': '2.05'}
+{'loss': '0.1055', 'grad_norm': '1.817', 'learning_rate': '6.007e-06', 'epoch': '2.1'}
+{'loss': '0.1258', 'grad_norm': '1.64', 'learning_rate': '5.673e-06', 'epoch': '2.15'}
+{'loss': '0.08761', 'grad_norm': '13.07', 'learning_rate': '5.34e-06', 'epoch': '2.2'}
+{'loss': '0.1045', 'grad_norm': '7.169', 'learning_rate': '5.007e-06', 'epoch': '2.25'}
+{'loss': '0.09492', 'grad_norm': '3.695', 'learning_rate': '4.673e-06', 'epoch': '2.3'}
+{'loss': '0.09578', 'grad_norm': '4.868', 'learning_rate': '4.34e-06', 'epoch': '2.35'}
+{'loss': '0.1095', 'grad_norm': '7.066', 'learning_rate': '4.007e-06', 'epoch': '2.4'}
+{'loss': '0.1023', 'grad_norm': '25.55', 'learning_rate': '3.673e-06', 'epoch': '2.45'}
+{'loss': '0.09162', 'grad_norm': '0.2507', 'learning_rate': '3.34e-06', 'epoch': '2.5'}
+{'loss': '0.09091', 'grad_norm': '6.892', 'learning_rate': '3.007e-06', 'epoch': '2.55'}
+{'loss': '0.07146', 'grad_norm': '0.03792', 'learning_rate': '2.673e-06', 'epoch': '2.6'}
+{'loss': '0.07999', 'grad_norm': '8.802', 'learning_rate': '2.34e-06', 'epoch': '2.65'}
+{'loss': '0.1339', 'grad_norm': '7.472', 'learning_rate': '2.007e-06', 'epoch': '2.7'}
+{'loss': '0.07065', 'grad_norm': '3.417', 'learning_rate': '1.673e-06', 'epoch': '2.75'}
+{'loss': '0.07152', 'grad_norm': '4.91', 'learning_rate': '1.34e-06', 'epoch': '2.8'}
+{'loss': '0.124', 'grad_norm': '4.503', 'learning_rate': '1.007e-06', 'epoch': '2.85'}
+{'loss': '0.1249', 'grad_norm': '9.946', 'learning_rate': '6.733e-07', 'epoch': '2.9'}
+{'loss': '0.1012', 'grad_norm': '7.187', 'learning_rate': '3.4e-07', 'epoch': '2.95'}
+{'loss': '0.08326', 'grad_norm': '2.385', 'learning_rate': '6.667e-09', 'epoch': '3'}
+{'eval_loss': '0.1552', 'eval_accuracy': '0.939', 'eval_f1': '0.9391', 'eval_runtime': '12.55', 'eval_samples_per_second': '159.3', 'eval_steps_per_second': '5.019', 'epoch': '3'}
+{'train_runtime': '1270', 'train_samples_per_second': '37.81', 'train_steps_per_second': '2.363', 'train_loss': '0.239', 'epoch': '3'}
+>> TEST metrics: {'eval_loss': 0.18711896240711212, 'eval_accuracy': 0.9295, 'eval_f1': 0.9290011212894149, 'eval_runtime': 13.4132, 'eval_samples_per_second': 149.107, 'eval_steps_per_second': 4.697, 'epoch': 3.0}
+>> saved model to ./distilbert-emotion

--- a/xai-for-transformer/distilbert-emotion-training/train_distilbert-emotion.py
+++ b/xai-for-transformer/distilbert-emotion-training/train_distilbert-emotion.py
@@ -1,0 +1,95 @@
+"""Fine-tune distilbert-base-uncased on dair-ai/emotion (6-class emotion classification).
+
+Produces the checkpoint used by the XAI transformer tutorials.
+Set SMOKE=1 for a tiny end-to-end sanity run.
+"""
+import os, inspect
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+os.environ.setdefault("HF_HUB_DISABLE_TELEMETRY", "1")
+
+import numpy as np
+from datasets import load_dataset
+from sklearn.metrics import accuracy_score, f1_score
+from transformers import (AutoTokenizer, AutoModelForSequenceClassification,
+                          TrainingArguments, Trainer, DataCollatorWithPadding, set_seed)
+
+SMOKE = os.environ.get("SMOKE") == "1"
+CKPT = "distilbert-base-uncased"
+OUTDIR = os.environ.get("OUTDIR", "./distilbert-emotion" if not SMOKE else "./smoke-out")
+set_seed(42)
+
+print(f">> loading dataset dair-ai/emotion (split)  [SMOKE={SMOKE}]", flush=True)
+ds = load_dataset("dair-ai/emotion", "split")
+labels = ds["train"].features["label"].names
+num_labels = len(labels)
+id2label = {i: l for i, l in enumerate(labels)}
+label2id = {l: i for i, l in enumerate(labels)}
+print(">> labels:", labels, flush=True)
+
+tok = AutoTokenizer.from_pretrained(CKPT)
+ds = ds.map(lambda b: tok(b["text"], truncation=True, max_length=128), batched=True)
+collator = DataCollatorWithPadding(tokenizer=tok)
+
+train_ds, eval_ds, test_ds = ds["train"], ds["validation"], ds["test"]
+if SMOKE:
+    train_ds = train_ds.select(range(200))
+    eval_ds = eval_ds.select(range(100))
+    test_ds = test_ds.select(range(100))
+
+model = AutoModelForSequenceClassification.from_pretrained(
+    CKPT, num_labels=num_labels, id2label=id2label, label2id=label2id)
+
+def compute_metrics(p):
+    preds = np.argmax(p.predictions, axis=1)
+    return {"accuracy": accuracy_score(p.label_ids, preds),
+            "f1": f1_score(p.label_ids, preds, average="weighted")}
+
+ta_params = set(inspect.signature(TrainingArguments.__init__).parameters)
+ta_kwargs = dict(
+    output_dir="./_trainer_out",
+    num_train_epochs=1 if SMOKE else 3,
+    per_device_train_batch_size=16,
+    per_device_eval_batch_size=32,
+    learning_rate=2e-5,
+    weight_decay=0.01,
+    logging_steps=50,
+    save_strategy="no",
+    report_to="none",
+)
+for k in ("eval_strategy", "evaluation_strategy"):   # arg renamed across versions
+    if k in ta_params:
+        ta_kwargs[k] = "epoch"
+        break
+args = TrainingArguments(**{k: v for k, v in ta_kwargs.items() if k in ta_params})
+
+tr_params = set(inspect.signature(Trainer.__init__).parameters)      # tokenizer -> processing_class
+tok_kw = {"processing_class": tok} if "processing_class" in tr_params else {"tokenizer": tok}
+trainer = Trainer(model=model, args=args, train_dataset=train_ds, eval_dataset=eval_ds,
+                  data_collator=collator, compute_metrics=compute_metrics, **tok_kw)
+
+print(f">> device={args.device}  epochs={args.num_train_epochs}  train={len(train_ds)}", flush=True)
+trainer.train()
+test_metrics = trainer.evaluate(test_ds)
+print(">> TEST metrics:", test_metrics, flush=True)
+
+model.save_pretrained(OUTDIR)
+tok.save_pretrained(OUTDIR)
+
+import json
+val_hist = [h for h in trainer.state.log_history if "eval_accuracy" in h]
+metrics = {
+    "model": CKPT,
+    "dataset": "dair-ai/emotion (split)",
+    "labels": labels,
+    "hyperparameters": {"epochs": args.num_train_epochs, "batch_size": 16,
+                        "learning_rate": 2e-5, "max_length": 128, "seed": 42, "device": str(args.device)},
+    "validation_per_epoch": [
+        {"epoch": h.get("epoch"), "accuracy": h.get("eval_accuracy"),
+         "f1_weighted": h.get("eval_f1"), "loss": h.get("eval_loss")} for h in val_hist],
+    "test": {"accuracy": test_metrics.get("eval_accuracy"),
+             "f1_weighted": test_metrics.get("eval_f1"), "loss": test_metrics.get("eval_loss")},
+}
+with open("metrics.json", "w") as f:
+    json.dump(metrics, f, indent=2)
+print(">> saved model to", os.path.abspath(OUTDIR), "| metrics -> metrics.json", flush=True)


### PR DESCRIPTION
Notebook 1 moves from translation to emotion classification, encoder only, so it matches the classification task the XAI tutorials build on. Started from @donatella-cea's restructuring in June, with the model, the text and the surrounding material filled in.

**What changed**

- `1-Tutorial_Transformer_Model.ipynb` is rewritten for emotion classification, with the section subtitles aligned to the video and component names, and the encoder description restored to include the layer count and the feed-forward detail.
- `1-Tutorial_Transformer_Model-Translation.ipynb` keeps the old translation notebook, linked from notebook 1 so the material is not lost.
- `0-Template-Notebook.ipynb` is a starting point for further XAI notebooks, including the device selection and model loading refactor.
- The transformer introduction video and the readthedocs links are added to notebook 1.

**The model**

`distilbert-emotion-training/` documents how the checkpoint was produced, so it can be reproduced rather than taken on trust: the training script, the exact package versions, the run log, `metrics.json` and a summary.

DistilBERT fine-tuned on `dair-ai/emotion`, 6 labels, 3 epochs, batch size 16, lr 2e-5, seed 42. Test accuracy 0.9295, weighted F1 0.9290. About 21 minutes on Apple Silicon.

**Requirements**

Three lines added, `accelerate`, `numpy` and `scikit-learn`, which notebook 1 and the training script import. `datasets` stays at main's 5.0.1.

**Note on the diff:** the branch had drifted 117 commits behind main, so I merged main into it first. Without that the diff showed 110 files and looked like it was deleting everything main gained since May. It is now the 10 files this work actually touches.

@donatella-cea over to you, you wrote two of these commits so parts of it will be familiar.
